### PR TITLE
updated no longer supported spreedly.com domain …

### DIFF
--- a/class.spreedly.inc
+++ b/class.spreedly.inc
@@ -46,7 +46,7 @@ class Spreedly {
 	public static function configure($site_name, $token) {
 		self::$site_name = $site_name;
 		self::$token = $token;
-		self::$base_uri = "https://spreedly.com/api/v4/$site_name";
+		self::$base_uri = "https://subs.pinpayments.com/api/v4/$site_name";
 	}
 
 	/**
@@ -56,7 +56,7 @@ class Spreedly {
 	 * token is returned with the subscriber (i.e. by SpreedlySubscriber::find)
 	 */
 	public static function get_edit_subscriber_url($token) {
-		return "https://spreedly.com/".self::$site_name."/subscriber_accounts/$token";
+		return "https://subs.pinpayments.com/".self::$site_name."/subscriber_accounts/$token";
 	}
 
 	/**
@@ -66,7 +66,7 @@ class Spreedly {
 	 * administer a user.
 	 */
 	public static function get_admin_subscriber_url($id) {
-		return "https://spreedly.com/".self::$site_name."/subscribers/$id";
+		return "https://subs.pinpayments.com/".self::$site_name."/subscribers/$id";
 	}
 
 	/**
@@ -103,7 +103,7 @@ class Spreedly {
 			throw new Exception("plan_id must be an integer");
 		}
 
-		$url = "https://spreedly.com/".self::$site_name."/subscribers/$id";
+		$url = "https://subs.pinpayments.com/".self::$site_name."/subscribers/$id";
 		if (is_string($options)) {
 			// In this case, $options is a string representing the screen name.
 			// For backwards compatibility only.

--- a/tests/SpreedlyTest.php
+++ b/tests/SpreedlyTest.php
@@ -40,7 +40,7 @@ class SpreedlyTest extends PHPUnit_Framework_TestCase {
 		global $test_site_name, $test_token;
 		Spreedly::configure($test_site_name, $test_token);
 		$url = Spreedly::get_admin_subscriber_url(123);
-		$this->assertEquals($url, "https://spreedly.com/{$test_site_name}/subscribers/123");
+		$this->assertEquals($url, "https://subs.pinpayments.com/{$test_site_name}/subscribers/123");
 	}
 
 	public function testConfigure() {
@@ -49,7 +49,7 @@ class SpreedlyTest extends PHPUnit_Framework_TestCase {
 		$this->assertNotNull(Spreedly::$token);
 		$this->assertEquals(Spreedly::$token, $test_token);
 		$this->assertEquals(Spreedly::$site_name, $test_site_name);
-		$this->assertEquals(Spreedly::$base_uri, "https://spreedly.com/api/v4/{$test_site_name}");
+		$this->assertEquals(Spreedly::$base_uri, "https://subs.pinpayments.com/api/v4/{$test_site_name}");
 	}
 
 	public function testCreate() {
@@ -88,7 +88,7 @@ class SpreedlyTest extends PHPUnit_Framework_TestCase {
 		global $test_site_name, $test_token;
 		Spreedly::configure($test_site_name, $test_token);
 		$url = Spreedly::get_edit_subscriber_url("XYZ");
-		$this->assertEquals("https://spreedly.com/{$test_site_name}/subscriber_accounts/XYZ", $url);
+		$this->assertEquals("https://subs.pinpayments.com/{$test_site_name}/subscriber_accounts/XYZ", $url);
 	}
 
 	public function testFind() {
@@ -221,31 +221,31 @@ class SpreedlyTest extends PHPUnit_Framework_TestCase {
 		Spreedly::configure($test_site_name, $test_token);
 
 		$url = Spreedly::get_subscribe_url(123, 10);
-		$this->assertEquals("https://spreedly.com/{$test_site_name}/subscribers/123/subscribe/10", $url);
+		$this->assertEquals("https://subs.pinpayments.com/{$test_site_name}/subscribers/123/subscribe/10", $url);
 
 		$url = Spreedly::get_subscribe_url(123, 10, "test_user");
-		$this->assertEquals("https://spreedly.com/{$test_site_name}/subscribers/123/subscribe/10/test_user", $url);
+		$this->assertEquals("https://subs.pinpayments.com/{$test_site_name}/subscribers/123/subscribe/10/test_user", $url);
 
 		$url = Spreedly::get_subscribe_url(123, 10, "test/ user");
-		$this->assertEquals("https://spreedly.com/{$test_site_name}/subscribers/123/subscribe/10/test%2F+user", $url);
+		$this->assertEquals("https://subs.pinpayments.com/{$test_site_name}/subscribers/123/subscribe/10/test%2F+user", $url);
 
 		$url = Spreedly::get_subscribe_url(123, 10, array(
 				"return_url"=>"http://www.google.com",
 				"email"=>"test@nospam.com",
 				"token"=>"XYZ"
 			));
-		$this->assertEquals("https://spreedly.com/{$test_site_name}/subscribers/123/XYZ/subscribe/10?return_url=http%3A%2F%2Fwww.google.com&email=test%40nospam.com", $url);
+		$this->assertEquals("https://subs.pinpayments.com/{$test_site_name}/subscribers/123/XYZ/subscribe/10?return_url=http%3A%2F%2Fwww.google.com&email=test%40nospam.com", $url);
 
 		$url = Spreedly::get_subscribe_url(123, 10, array(
 				"screen_name"=>"joe",
 				"email"=>"test@nospam.com",
 			));
-		$this->assertEquals("https://spreedly.com/{$test_site_name}/subscribers/123/subscribe/10/joe?email=test%40nospam.com", $url);
+		$this->assertEquals("https://subs.pinpayments.com/{$test_site_name}/subscribers/123/subscribe/10/joe?email=test%40nospam.com", $url);
 
 		$url = Spreedly::get_subscribe_url(123, 10, array(
 				"screen_name"=>"joe"
 			));
-		$this->assertEquals("https://spreedly.com/{$test_site_name}/subscribers/123/subscribe/10/joe", $url);
+		$this->assertEquals("https://subs.pinpayments.com/{$test_site_name}/subscribers/123/subscribe/10/joe", $url);
 
 		try {
 			$url = Spreedly::get_subscribe_url(123, 10, array(


### PR DESCRIPTION
…to subs.pinpayments.com

Email from support@pinpayments.com

Hello,

On Tuesday, 23 June 2015, at 4:00 PM UTC, Pin Payments Subscriptions will no longer be accessible via the spreedly.com domain name; you must use subs.pinpayments.com instead. If you haven't already, please make sure your websites and software use the correct domain.

We originally announced this to you this several weeks ago; this is simply a last-minute reminder. You're receiving this email because our records indicate that between January and March 2015, you owned at least one site on Pin Payments Subscriptions, and that someone interacted with it via spreedly.com. It's possible that you've already made the necessary changes.

If you have any questions, feel free to email us at support@pinpayments.com, or just reply to this email. We're happy to help.

Thank you,
Pin Payments